### PR TITLE
Use autostash instead of manual stash

### DIFF
--- a/git-rebase.zsh
+++ b/git-rebase.zsh
@@ -1,12 +1,11 @@
 rebase() {
-    printf "Stash? (y/n): "
+    printf "Stash? (Y/n): "
     read -r shouldStash
 
-    if [[ "$shouldStash" = "n" ]]; then
-        shouldStash=false
+    if [[ ! $shouldStash =~ ^[Nn]$ ]]; then
+        stashArg='--autostash'
     else
-        shouldStash=true
-        git stash
+        stashArg='--no-autostash'
     fi
 
     git log --color --graph --pretty=format:'%Cgreen%h%Creset %C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | cat -n | less
@@ -14,9 +13,5 @@ rebase() {
     printf "Commit #: "
     read -r commit
 
-    git rebase -i HEAD~$commit
-
-    if [[ $shouldStash -eq true ]]; then
-        git stash pop > /dev/null
-    fi
+    git rebase -i $stashArg HEAD~$commit
 }


### PR DESCRIPTION
I've been using this for a while now but I had some hiccups with the stash behaviour on occasion, mainly with the stash being popped before the rebase was completed.
I discovered there's an `--autostash` feature on [git rebase](https://git-scm.com/docs/git-rebase#git-rebase-rebaseautoStash), which seems to work quite nicely for this sort of behaviour and should remove the intermediate steps.

See attached screenshot on how it looks:

<img width="753" alt="autostash" src="https://user-images.githubusercontent.com/511547/42772392-3316d456-8922-11e8-8d0e-302f79da2aa4.png">


Also, secondary thing, I capitalized the  "Y" in the stash question to show it's the default behaviour if you fail to type in "n".