### PR TITLE
Quieter stash and Autosquash support

### DIFF
--- a/git-rebase.zsh
+++ b/git-rebase.zsh
@@ -17,5 +17,5 @@ rebase() {
     printf "Commit #: "
     read -r commit
 
-    git rebase -i $stashArg HEAD~$commit
+    git rebase -i --autosquash $stashArg HEAD~$commit
 }

--- a/git-rebase.zsh
+++ b/git-rebase.zsh
@@ -1,12 +1,16 @@
 rebase() {
-    printf "Stash? (Y/n): "
-    read -r shouldStash
+    stashArg='--no-autostash'
 
-    if [[ ! $shouldStash =~ ^[Nn]$ ]]; then
-        stashArg='--autostash'
-    else
-        stashArg='--no-autostash'
+    if ! git diff-index --quiet HEAD; then
+        # We only care about stashing if there are unstaged changes
+        printf "Stash? (Y/n): "
+        read -r shouldStash
+
+        if [[ ! $shouldStash =~ ^[Nn]$ ]]; then
+            stashArg='--autostash'
+        fi
     fi
+
 
     git log --color --graph --pretty=format:'%Cgreen%h%Creset %C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | cat -n | less
 


### PR DESCRIPTION
Hey @smallhadroncollider !

A couple of changes that sprang from my day-to-day use experience so far:

- Only ask whether to stash if there is anything to stash.
  If there are no unstaged changes then we don't need to bother.
- Add `--autosquash` as a default parameter for rebase.
  Autosquash will take any fixup commits and automatically mark them as `fixup` and order them appropriately underneath their parent commit. [More on this flow](https://thoughtbot.com/blog/autosquashing-git-commits). I don't think it will affect anyone who doesn't use it.